### PR TITLE
Windows support

### DIFF
--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -17,31 +17,11 @@ function compileWASM (config) {
     return process.stdout.write(colors.red(`Error: Could not find emscripten directory at ${config.emscripten_path}\n`));
   }
 
-  // format exported functions, if present, from config for shell script
-  let expFuncStr = '';
-  if (config.exported_functions && config.exported_functions.length > 0) {
-    let expFuncs = config.exported_functions.reduce((acc, val) => acc.concat('\'', val, '\'\,'), '[');
-    expFuncs = expFuncs.substring(0, expFuncs.length - 1).concat(']');
-    expFuncStr = `-s EXPORTED_FUNCTIONS="${expFuncs}" `;
-  }
-
-  // format flags from config for shell script
-  const flags = config.flags.reduce((acc, val) => acc.concat(' ', val), '');
-
+  const shellScript = getShellScript(config);
+  
   process.stdout.write(colors.cyan('Running emscripten...\n'));
-
   // execute shell script
-  exec(`
-  if [[ :$PATH: != *:"/emsdk":* ]]
-  then
-    # use path to emsdk folder, relative to project directory
-    BASEDIR="${config.emscripten_path}"
-    EMSDK_ENV=$(find "$BASEDIR" -type f -name "emsdk_env.sh")
-    source "$EMSDK_ENV"
-  fi
-
-  emcc -o ${config.outputfile} ${config.inputfile} ${expFuncStr} ${flags}
-  `, (error, stdout, stderr) => {
+  exec(shellScript, (error, stdout, stderr) => {
     // check for emcc compile errors
     if (stderr) {
       process.stderr.write(colors.red.bold('EMSCRIPTEN COMPILE ERROR\n'));
@@ -76,6 +56,45 @@ function insertEventListener (config) {
       fs.renameSync(tempFile, outFile);
     });
   });
+}
+
+function getShellScript(config) {
+  const compileCommand = getCompileCommand(config);
+
+  if (isWin()) {
+    return compileCommand;
+  } else {
+    return `
+      if [[ :$PATH: != *:"/emsdk":* ]]
+      then
+        # use path to emsdk folder, relative to project directory
+        BASEDIR="${config.emscripten_path}"
+        EMSDK_ENV=$(find "$BASEDIR" -type f -name "emsdk_env.sh")
+        source "$EMSDK_ENV"
+      fi
+
+      ${compileCommand}
+      `;
+  }
+}
+
+function getCompileCommand(config) {
+  // format exported functions, if present, from config for shell script
+  let expFuncStr = '';
+  if (config.exported_functions && config.exported_functions.length > 0) {
+    let expFuncs = config.exported_functions.reduce((acc, val) => acc.concat('\'', val, '\'\,'), '[');
+    expFuncs = expFuncs.substring(0, expFuncs.length - 1).concat(']');
+    expFuncStr = `-s EXPORTED_FUNCTIONS="${expFuncs}" `;
+  }
+
+  // format flags from config for shell script
+  const flags = config.flags.reduce((acc, val) => acc.concat(' ', val), '');
+
+  return `emcc -o ${config.outputfile} ${config.inputfile} ${expFuncStr} ${flags}`;
+}
+
+function isWin() {
+  return /^win/.test(process.platform);
 }
 
 module.exports = {


### PR DESCRIPTION
As mentioned [here](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html) , the additional step before compile command is required only for Linux and Mac OS X. Therefore, I just skipped this step for windows.