### PR TITLE
Moderately useful emcmake support.

### DIFF
--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -27,21 +27,37 @@ function compileWASM (config) {
 
   // format flags from config for shell script
   const flags = config.flags.reduce((acc, val) => acc.concat(' ', val), '');
-
+  // construct the default compile mode string.
+  let commandStr = `emcc -o ${config.outputfile} ${config.inputfile} ${expFuncStr} ${flags}`;
+  // generate a command string suitable for cmake
+  if(config.mode == "build") {
+    // assuming make
+    config.generator = config.generator ? config.generator : 'make';
+    switch(config.generator) {
+      case 'ninja':
+        config.gen_flag = 'Ninja';
+      default:
+        config.gen_flag = '"Unix Makefiles"';
+        break;
+    }
+    
+    commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} ..`+
+      ` && emmake ${config.generator}`;
+  }
   process.stdout.write(colors.cyan('Running emscripten...\n'));
 
   // execute shell script
   exec(`
   if [[ :$PATH: != *:"/emsdk":* ]]
   then
-    # use path to emsdk folder, relative to project directory
+\    # use path to emsdk folder, relative to project directory
     BASEDIR="${config.emscripten_path}"
     EMSDK_ENV=$(find "$BASEDIR" -type f -name "emsdk_env.sh")
     source "$EMSDK_ENV"
   fi
 
-  emcc -o ${config.outputfile} ${config.inputfile} ${expFuncStr} ${flags}
-  `, (error, stdout, stderr) => {
+  ${commandStr}
+  `, { shell: '/bin/bash' }, (error, stdout, stderr) => {
     // check for emcc compile errors
     if (stderr) {
       process.stderr.write(colors.red.bold('EMSCRIPTEN COMPILE ERROR\n'));

--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const exec = require('child_process').exec;
 const colors = require('colors');
+const os = require('os'),cpuCount = os.cpus().length;
 
 /**
  * This function pulls parameters from the wasm.config.js file,
@@ -42,7 +43,7 @@ function compileWASM (config) {
     }
     
     commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} ..`+
-      ` && emmake ${config.generator}`;
+      ` && emmake ${config.generator} -j${cpuCount-1}`;
   }
   process.stdout.write(colors.cyan('Running emscripten...\n'));
 

--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -41,8 +41,8 @@ function compileWASM (config) {
         config.gen_flag = '"Unix Makefiles"';
         break;
     }
-    
-    commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} ..`+
+    // pass through cmake configuration, inc. compiler flags, exported functions
+    commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} -DWASM_CXXFLAGS=${flags} -DEXPORTED_FUNCTIONS=${expFuncStr} ..`+
       ` && emmake ${config.generator} -j${cpuCount-1}`;
   }
   process.stdout.write(colors.cyan('Running emscripten...\n'));

--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -51,7 +51,7 @@ function compileWASM (config) {
   exec(`
   if [[ :$PATH: != *:"/emsdk":* ]]
   then
-\    # use path to emsdk folder, relative to project directory
+    # use path to emsdk folder, relative to project directory
     BASEDIR="${config.emscripten_path}"
     EMSDK_ENV=$(find "$BASEDIR" -type f -name "emsdk_env.sh")
     source "$EMSDK_ENV"

--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -9,7 +9,7 @@ const os = require('os'),cpuCount = os.cpus().length;
  * This function pulls parameters from the wasm.config.js file,
  * sets the emcc environment and calls the emcc compile arguments
  * via shell commands
- * @param {Object} config 
+ * @param {Object} config
  */
 function compileWASM (config) {
 
@@ -41,9 +41,14 @@ function compileWASM (config) {
         config.gen_flag = '"Unix Makefiles"';
         break;
     }
+    // need to triple escape double quotes
+    expFuncStr = expFuncStr.replace(/"/g, '\\\"');
+    let modFlags = flags.replace(/"/g, '\\\"');
+    let cxxFlagStr = `SET(WASM_CXXFLAGS "${modFlags} ${expFuncStr}" CACHE PATH "")`;
     // pass through cmake configuration, inc. compiler flags, exported functions
-    commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} -DWASM_CXXFLAGS=${flags} -DEXPORTED_FUNCTIONS=${expFuncStr} ..`+
-      ` && emmake ${config.generator} -j${cpuCount-1}`;
+    commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} `+
+      `-DWASM_CXXFLAGS=\"${modFlags} ${expFuncStr}\" ` +
+      `.. && emmake ${config.generator} -j${cpuCount-1}`;
   }
   process.stdout.write(colors.cyan('Running emscripten...\n'));
 
@@ -76,7 +81,7 @@ function compileWASM (config) {
  * to notify us when WebAssembly has finished loading. As of April 2017,
  * this is needed because Firefox doesn't reliably emmit a script onload
  * notification
- * @param {Object} config 
+ * @param {Object} config
  */
 function insertEventListener (config) {
   let outFile = path.join(process.cwd(), config.outputfile);


### PR DESCRIPTION
Specifying mode: build switches to running emcmake cmake, then emmake make in the wasm dir.
EXPORTED_FUNCTIONS is available to the cmake environment, as is WASM_CXXFLAGS.

The below is sufficient for linking with wasm-init from inside a cmakelists.txt file:
```
set(CMAKE_CXX_FLAGS "${WASM_CXXFLAGS} ${EXPORTED_FUNCTIONS}")
```