### PR TITLE
windows partial support

### DIFF
--- a/lib/compileWASM.js
+++ b/lib/compileWASM.js
@@ -18,55 +18,12 @@ function compileWASM (config) {
     return process.stdout.write(colors.red(`Error: Could not find emscripten directory at ${config.emscripten_path}\n`));
   }
 
+  const shell = isWin() ? 'cmd.exe' : '/bin/bash';
   const shellScript = getShellScript(config);
-  
-  // format exported functions, if present, from config for shell script
-  let expFuncStr = '';
-  if (config.exported_functions && config.exported_functions.length > 0) {
-    let expFuncs = config.exported_functions.reduce((acc, val) => acc.concat('\'', val, '\'\,'), '[');
-    expFuncs = expFuncs.substring(0, expFuncs.length - 1).concat(']');
-    expFuncStr = `-s EXPORTED_FUNCTIONS="${expFuncs}" `;
-  }
 
-  // format flags from config for shell script
-  const flags = config.flags.reduce((acc, val) => acc.concat(' ', val), '');
-  // construct the default compile mode string.
-  let commandStr = `emcc -o ${config.outputfile} ${config.inputfile} ${expFuncStr} ${flags}`;
-  // generate a command string suitable for cmake
-  if(config.mode == "build") {
-    // assuming make
-    config.generator = config.generator ? config.generator : 'make';
-    switch(config.generator) {
-      case 'ninja':
-        config.gen_flag = 'Ninja';
-      default:
-        config.gen_flag = '"Unix Makefiles"';
-        break;
-    }
-    // need to triple escape double quotes
-    expFuncStr = expFuncStr.replace(/"/g, '\\\"');
-    let modFlags = flags.replace(/"/g, '\\\"');
-    let cxxFlagStr = `SET(WASM_CXXFLAGS "${modFlags} ${expFuncStr}" CACHE PATH "")`;
-    // pass through cmake configuration, inc. compiler flags, exported functions
-    commandStr = `cd wasm && emcmake cmake -G ${config.gen_flag} `+
-      `-DWASM_CXXFLAGS=\"${modFlags} ${expFuncStr}\" ` +
-      `.. && emmake ${config.generator} -j${cpuCount-1}`;
-  }
   process.stdout.write(colors.cyan('Running emscripten...\n'));
   // execute shell script
-  // exec(shellScript, (error, stdout, stderr) => {
-
-  exec(`
-  if [[ :$PATH: != *:"/emsdk":* ]]
-  then
-    # use path to emsdk folder, relative to project directory
-    BASEDIR="${config.emscripten_path}"
-    EMSDK_ENV=$(find "$BASEDIR" -type f -name "emsdk_env.sh")
-    source "$EMSDK_ENV"
-  fi
-
-  ${commandStr}
-  `, { shell: '/bin/bash' }, (error, stdout, stderr) => {
+  exec(shellScript, { shell }, (error, stdout, stderr) => {
     // check for emcc compile errors
     if (stderr) {
       process.stderr.write(colors.red.bold('EMSCRIPTEN COMPILE ERROR\n'));
@@ -134,6 +91,26 @@ function getCompileCommand(config) {
 
   // format flags from config for shell script
   const flags = config.flags.reduce((acc, val) => acc.concat(' ', val), '');
+  // generate a command string suitable for cmake
+  if(config.mode == "build") {
+    // assuming make
+    config.generator = config.generator ? config.generator : 'make';
+    switch(config.generator) {
+      case 'ninja':
+        config.gen_flag = 'Ninja';
+      default:
+        config.gen_flag = '"Unix Makefiles"';
+        break;
+    }
+    // need to triple escape double quotes
+    expFuncStr = expFuncStr.replace(/"/g, '\\\"');
+    let modFlags = flags.replace(/"/g, '\\\"');
+    let cxxFlagStr = `SET(WASM_CXXFLAGS "${modFlags} ${expFuncStr}" CACHE PATH "")`;
+    // pass through cmake configuration, inc. compiler flags, exported functions
+    return `cd wasm && emcmake cmake -G ${config.gen_flag} `+
+      `-DWASM_CXXFLAGS=\"${modFlags} ${expFuncStr}\" ` +
+      `.. && emmake ${config.generator} -j${cpuCount-1}`;
+  }
 
   return `emcc -o ${config.outputfile} ${config.inputfile} ${expFuncStr} ${flags}`;
 }


### PR DESCRIPTION
In reference to [this discussion](https://github.com/shamadee/wasm-init/pull/20) 
Sorry for waiting so long, it took me more time than I exptected.

You're right about PATH, unfortunately, I don't see any decent solution right now.
To add proper paths and environment variables for running emscripten, You need run emsdk_env.bat from emsdk directory.
However, this script sets path to nodejs directory inside emsdk directory. Because nodejs from esdk is in version 4.1.1, ES6 features from wasm-init package will not work..

Solution which I propose for now, is running  [`emsdk activate`](http://webassembly.org/getting-started/developers-guide/) command with `--global` flag, and then remove emsdk nodejs path from environment variables. It should work with this PR.

If I will have more time, I will try to automate those tasks.